### PR TITLE
ROMAJI_MAX_LENGTH -> KANA_MAX_LENGTH

### DIFF
--- a/lib/romaji.rb
+++ b/lib/romaji.rb
@@ -80,7 +80,7 @@ module Romaji
         next
       end
 
-      ROMAJI_MAX_LENGTH.downto(1) do |t|
+      KANA_MAX_LENGTH.downto(1) do |t|
         substr = chars.slice(pos, t).join
         k = KANA2ROMAJI[substr]
         if k


### PR DESCRIPTION
If I understand the code correctly, there are no kana sequences of length 3 in `KANA2ROMAJI`
