### PR TITLE
Add license to gemspec

### DIFF
--- a/romaji.gemspec
+++ b/romaji.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |gem|
   gem.description   = 'Yet another Romaji-Kana transliterator'
   gem.summary       = 'Yet another Romaji-Kana transliterator'
   gem.homepage      = "https://github.com/makimoto/romaji"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
This PR adds  license  to gemspec.
It is friendly to write license because people can know how this gem are permitted to use. 
Also describing LICENSES on rubygems.org (https://rubygems.org/gems/romaji)