### PR TITLE
Add nkf to gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/Gemfile.lock
+/coverage/*

--- a/romaji.gemspec
+++ b/romaji.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Romaji::VERSION
 
+  gem.add_dependency('nkf', '>= 0.2.0')
   gem.add_dependency('rake', '>= 0.8.0')
   gem.add_development_dependency('rspec', '>= 2.8.0')
   gem.add_development_dependency('pry', ['>= 0'])


### PR DESCRIPTION
The nkf gem will no longer be part of the default gems since Ruby 3.4.0.