### PR TITLE
Add `nkf` gem to dependencies

### DIFF
--- a/romaji.gemspec
+++ b/romaji.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   gem.version       = Romaji::VERSION
 
   gem.add_dependency('rake', '>= 0.8.0')
+  gem.add_dependency('nkf', '>= 0.2.0')
   gem.add_development_dependency('rspec', '>= 2.8.0')
   gem.add_development_dependency('pry', ['>= 0'])
   gem.add_development_dependency('guard', '>= 1.0.1')


### PR DESCRIPTION
## Issue

When using this gem, the following warning appears. It indicates that gem `nkf` was loaded from the standard library but will not be part of the default gems from Ruby 3.4.0. This can cause runtime errors when updating Ruby.

```console
$ rake spec
...
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
/home/otegami/.rbenv/versions/3.4.0-rc1/lib/ruby/gems/3.4.0+1/gems/rspec-core-3.13.2/exe/rspec:4: warning: nkf was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
You can add nkf to your Gemfile or gemspec to silence this warning.

An error occurred while loading ./spec/romaji_spec.rb.
Failure/Error: require 'nkf'

LoadError:
  cannot load such file -- nkf
No examples found.
...
```

## Cause

Starting with Ruby 3.4.0, the `nkf` library is no longer included as a default gem. The application relies on `nkf` without declaring it as an explicit dependency, leading to warnings and potential load failures.

## Solution

Add gem `nkf` as a dependency in the gemspec to ensure it is available.